### PR TITLE
Bug fix for InvokeMethod only accepting string value as return type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,7 @@
 ## 0.0.4
 
 * Minor Updates.
+
+## 0.0.5
+
+* Fixed a bug where invokeMethod only accepting string as return value

--- a/android/src/main/kotlin/dev/asdevs/signalr_flutter/SignalR.kt
+++ b/android/src/main/kotlin/dev/asdevs/signalr_flutter/SignalR.kt
@@ -118,17 +118,17 @@ object SignalR {
 
     fun invokeServerMethod(methodName: String, args: List<Any>, result: Result) {
         try {
-            val res: SignalRFuture<String> = when (args.count()) {
-                0 -> hub.invoke(String::class.java, methodName)
-                1 -> hub.invoke(String::class.java, methodName, args[0])
-                2 -> hub.invoke(String::class.java, methodName, args[0], args[1])
-                3 -> hub.invoke(String::class.java, methodName, args[0], args[1], args[2])
-                4 -> hub.invoke(String::class.java, methodName, args[0], args[1], args[2], args[3])
-                5 -> hub.invoke(String::class.java, methodName, args[0], args[1], args[2], args[3], args[4])
+            val res: SignalRFuture<Any> = when (args.count()) {
+                0 -> hub.invoke(Any::class.java, methodName)
+                1 -> hub.invoke(Any::class.java, methodName, args[0])
+                2 -> hub.invoke(Any::class.java, methodName, args[0], args[1])
+                3 -> hub.invoke(Any::class.java, methodName, args[0], args[1], args[2])
+                4 -> hub.invoke(Any::class.java, methodName, args[0], args[1], args[2], args[3])
+                5 -> hub.invoke(Any::class.java, methodName, args[0], args[1], args[2], args[3], args[4])
                 else -> throw Exception("Maximum 5 arguments supported. Your arguments List count is ${args.count()}.")
             }
 
-            res.done { msg: String? ->
+            res.done { msg: Any? ->
                 android.os.Handler(Looper.getMainLooper()).post {
                     result.success(msg)
                 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -94,7 +94,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.4"
+    version: "0.0.5"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: signalr_flutter
 description: A flutter plugin for .net SignalR client. This client is for ASP.Net SignalR, not for .Net Core SignalR.
-version: 0.0.4
+version: 0.0.5
 homepage: https://github.com/AS-Devs/signalr_flutter
 
 environment:


### PR DESCRIPTION
This bug currently exists for android only. iOS implementation should be fine.

- [x] Changes in native Android code

- [x] Test on Android device

- [x] Test on iOS device